### PR TITLE
Refine discovery defaults and extend TLS coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Guidelines
+
+- Run `gofmt` on all Go source files that you touch.
+- Keep Go packages covered by unit tests; add table-driven tests when sensible.
+- Update or add documentation in `docs/` when behaviour or design changes.
+- Prefer descriptive commit messages and PR summaries.
+- When editing Markdown, wrap lines at roughly 100 characters unless a table or URL would break.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ Run `go test ./...` for the fast unit suite. The [testing strategy](docs/testing
 will expand coverage with TLS failure injection and future integration checks. Unit coverage now
 includes discovery of Teleport profiles, `/webapi/ping` lookups, and TLS probe execution with
 in-memory certificates so handshake, ALPN mismatch, and failure classifications stay regression-free.
+The same document outlines a short manual validation loop for exercising the tool against a real
+Teleport cluster before the full integration harness is in place.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-tlscheck
+# tlscheck
+
+Prototype harness for Teleport proxy TLS connectivity probing. See [docs/design.md](docs/design.md) for the current design and test matrix.
+
+## CLI plan scaffolding
+
+The `tlscheck` CLI currently builds a JSON plan that enumerates every `(service, port, SNI, ALPN)` combination the harness will probe. Example:
+
+```shell
+go run ./cmd/tlscheck
+```
+
+Flags:
+
+* `--proxy-server` – Teleport proxy public DNS name. When omitted, the CLI reads
+  `$TELEPORT_HOME/current-profile` (or `~/.tsh/current-profile`) to locate the active profile and
+  derives the public address automatically.
+* `--repeat` – Attempts per `(SNI, ALPN, IP)` combination. Defaults to `1` per the latest guidance.
+* `--services` – Optional comma-separated allow-list of service keys (for example
+  `proxy_web,proxy_ssh`). Valid service keys: `proxy_web`, `reverse_tunnel`, `proxy_ssh`,
+  `proxy_ssh_grpc`, `auth`, `kube`, `db_postgres`, `db_mysql`, `db_mongo`, `db_redis`, `app`,
+  `desktop`.
+* `-v, --version` – Print the tlscheck build identifier and exit.
+
+Cluster name and Teleport version are no longer accepted as flags; the CLI always retrieves them via
+`/webapi/ping` after resolving the proxy address. If no active Teleport profile exists, tlscheck
+prints `no active tsh profile. specify a proxy via --proxy-server` alongside the usage banner.
+
+The command respects `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` to mirror `tsh` behaviour. Proxy settings are echoed back in the generated plan for traceability.
+
+## Testing
+
+Run `go test ./...` for the fast unit suite. The [testing strategy](docs/testing.md) describes how we
+will expand coverage with TLS failure injection and future integration checks. Unit coverage now
+includes discovery of Teleport profiles, `/webapi/ping` lookups, and TLS probe execution with
+in-memory certificates so handshake, ALPN mismatch, and failure classifications stay regression-free.

--- a/cmd/tlscheck/main.go
+++ b/cmd/tlscheck/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/programmerq/tlscheck/internal/config"
+	"github.com/programmerq/tlscheck/internal/plan"
+	"github.com/programmerq/tlscheck/internal/version"
+)
+
+func main() {
+	opts, showVersion, err := config.ParseArgs(os.Args[1:], plan.ServiceKeys())
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "failed to parse arguments: %v\n", err)
+		os.Exit(2)
+	}
+
+	if showVersion {
+		fmt.Fprintln(os.Stdout, version.Version)
+		return
+	}
+
+	ctx := context.Background()
+	resolved, err := config.ResolveRuntime(ctx, opts)
+	if err != nil {
+		if errors.Is(err, config.ErrProxyServerRequired) {
+			fmt.Fprintln(os.Stderr, "no active tsh profile. specify a proxy via --proxy-server")
+			config.Usage()
+			os.Exit(2)
+		}
+		fmt.Fprintf(os.Stderr, "failed to resolve runtime defaults: %v\n", err)
+		os.Exit(1)
+	}
+
+	probePlan, err := plan.Build(resolved)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build probe plan: %v\n", err)
+		os.Exit(1)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(probePlan); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to render plan: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,39 @@
+# TLSCheck Probe Harness Design
+
+## Version-Aware Connectivity Matrix
+
+| Service | Port (Separate / Legacy) | SNI (Multiplex) | ALPN List Proposed (Multiplex) | Upgrade Path When Behind L7 (Teleport version) |
+| --- | --- | --- | --- | --- |
+| Proxy Web UI & HTTPS API (/webapi/ping, /webapi/find, auth flows) | 3080 (or 443 if not multiplexing) | cluster.example.com (public DNS) | h2,http/1.1 | v15.1–v17: attempt `Upgrade: websocket` and `Upgrade: alpn` (fallback `alpn-ping`) against `/webapi/connectionupgrade` with mirrored `X-Teleport-Upgrade` header. v18+: WebSocket only. |
+| Reverse tunnel (client/agent testing proxy’s tunnel entry) | 3024 | Public cluster DNS (probe raw IP with identical SNI) | teleport-reversetunnel | Same upgrade behavior (WebSocket preferred ≥15.1; legacy `alpn`/`alpn-ping` acceptable only <18). |
+| Proxy SSH (tsh→proxy for node SSH) | 3023 | Public cluster DNS (include base16-encoded internal SNI variant when dialing raw IP) | teleport-proxy-ssh | Same upgrade behavior as above. |
+| Proxy SSH-gRPC (internal SSH over gRPC transport via proxy) | — | Public cluster DNS | teleport-proxy-ssh-grpc (negotiates h2) | Same upgrade behavior as above. |
+| Auth via Proxy (tsh or agents dialing Auth through proxy) | (Auth gRPC is 3025; clients use proxy via TLS routing) | teleport-auth@<cluster-name> (then h2) | teleport-auth@<cluster-name> | Same upgrade behavior as above. |
+| Kubernetes API via Proxy | 3026 | kube-teleport-proxy-alpn.<cluster-name> (special SNI prefix) | h2,http/1.1 | Same upgrade behavior; L7-compatible TLS routing introduced in 13+, relevant in 15–18. |
+| Databases via Proxy (tsh upstream hop) | Split listeners: Postgres 5432, MySQL 3036, MongoDB 27017, Redis 6379 | Public cluster DNS | Upstream ALPN supplied by `tsh` | Same upgrade behavior; harness dials ALPN path explicitly. |
+| App Access (HTTP apps) | Multiplexed on web | Public cluster DNS | h2,http/1.1 | Same upgrade behavior. |
+| Desktop Access (RDP control plane) | Multiplexed on web | Public cluster DNS | gRPC/HTTP stack → effectively h2,http/1.1 | Same upgrade behavior. |
+
+## Notes and Expectations
+
+- **Internal SNI forms**: compute the base16-encoded cluster name after `/webapi/ping`. These SNIs do not resolve in DNS and are only supplied during TLS handshakes when dialing a resolved proxy IP.
+- **HTTP CONNECT**: honor `HTTPS_PROXY` / `HTTP_PROXY` settings. Log the CONNECT target and any proxy response headers when a proxy is used to identify middleboxes that strip upgrade headers.
+- **Runtime discovery**: when CLI flags omit cluster metadata, read the active Teleport profile via `$TELEPORT_HOME/current-profile` (or `~/.tsh/current-profile`) and query `/webapi/ping` to obtain the public address, cluster name, and Teleport version automatically.
+- **Upgrade contract**: send `GET /webapi/connectionupgrade` with `Connection: Upgrade`, the relevant `Upgrade` token (`websocket`, `alpn`, `alpn-ping`), and `X-Teleport-Upgrade` mirroring the value to survive middleboxes.
+- **Version gates**: WebSocket upgrade landed in the 15.x line and is mandatory in 18+. Probes for v15–v17 should attempt both WebSocket and legacy upgrades; v18+ uses WebSocket only.
+- **Certificates**: leaf certificates from proxy or auth must chain to the cluster Host CA and present the expected identity. Flag mismatches.
+
+## Probe Execution Defaults
+
+- **Repeat count**: default to a single attempt (`N = 1`) per `(SNI, ALPN, IP)` combination. Allow opt-in configuration for higher counts when deeper sampling is required.
+- **Failure taxonomy**: classify probe outcomes into `handshake_failed`, `upgrade_rejected`, `alpn_mismatch`, `unexpected_cert`, `timeout`, and `proxy_connect_failed`.
+- **Logging**: capture target host, resolved IP, SNI sent, ALPN list, negotiated protocol, leaf certificate fingerprint/subject, upgrade path details, and proxy metadata when applicable.
+
+## Implementation Roadmap
+
+1. Implement a lightweight Go CLI (this repository) that mirrors `tsh` probe ordering (`/webapi/ping` before ALPN/upgrade attempts).
+2. Build a modular probe engine capable of dialing via direct sockets or HTTP CONNECT based on environment configuration.
+3. Emit structured JSONL records per attempt with the fields listed above.
+4. Provide configuration knobs for Teleport version bands to adjust upgrade behavior automatically.
+5. Back the probe engine with the multilayered [testing strategy](testing.md) so TLS failures can be
+   injected deterministically in unit and integration environments.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,61 @@
+# Testing Strategy
+
+This project needs high confidence before running probes against production Teleport clusters.
+The following layers ensure we can iterate safely while surfacing regressions quickly.
+
+## Unit Tests
+
+* `internal/config` – table-driven coverage for argument parsing, proxy detection, and service
+  filtering. These tests validate defaults such as repeat counts and ensure flag changes do not
+  silently break backwards compatibility.
+* `internal/plan` – golden-style tests that assert the matrix of services, upgrade sequences, and
+  notes for each Teleport version band. These tests pin behaviour such as the base16 cluster hint
+  and the WebSocket-only transition in v18+.
+* `internal/probe` – TLS harnesses that spin up in-memory listeners. They now confirm that asking
+  for `teleport.example.com` via SNI returns a leaf certificate for the same host, and classify
+  ALPN mismatches and handshake failures without touching external networks.
+
+Unit tests will grow to include serialization helpers, SNI/ALPN builders, and any future resolvers.
+Mocks in this layer remain simple structs so that higher-level probe tests can inject synthetic
+failures without bringing up full network stacks.
+
+## Probe Engine Tests
+
+Once the dialer implementation lands, we will abstract network I/O behind interfaces. A probe will
+receive a `Dialer` and `HTTPClient` so that tests can swap in in-memory transports. We will use the
+following primitives to simulate TLS outcomes:
+
+* `net.Pipe` with `tls.Server`/`tls.Client` wrapped around each endpoint to emulate handshake
+  success, ALPN negotiation, or explicit handshake failures.
+* Custom `tls.Config` hooks (`GetConfigForClient`, `VerifyPeerCertificate`) that inject specific
+  certificate chains or errors to test `unexpected_cert` and `handshake_failed` paths.
+* `httptest.Server` instances configured with middleware that strips or rewrites Upgrade headers so
+  we can assert the `upgrade_rejected` classification and proxy metadata logging.
+
+These tests will be table-driven and will produce JSONL outputs that we compare against fixtures,
+allowing us to pin both successful probe results and nuanced failure taxonomies.
+
+## Integration Tests
+
+A future phase will provision ephemeral Teleport clusters (via docker-compose or Terraform) covering
+version bands v15–v18. Against these clusters we will run the full CLI end-to-end, verifying that the
+observed TLS handshake metadata matches expectations (cert identities, negotiated protocols, upgrade
+behaviour). These tests will run behind a synthetic L7 proxy that can strip Upgrade headers to ensure
+proxy reporting remains accurate.
+
+Until the integration environment exists, we will simulate a subset locally using `minica`-issued
+certificates and lightweight Go servers that implement the Teleport upgrade contract endpoints.
+
+## Failure Injection Helpers
+
+To make failure injection repeatable, we will maintain helper builders that describe a probe attempt
+(e.g. desired ALPN, SNI, certificate chain) and produce mock listeners. Tests will compose these
+helpers to assert that classification (`handshake_failed`, `timeout`, etc.) and logging fields are
+set correctly. The helpers will track outstanding goroutines and close listeners at the end of each
+test to avoid resource leaks.
+
+## CI Hooks
+
+`go test ./...` remains the default check. As we add integration coverage, we will gate the heavier
+scenarios behind build tags (`integration`) so that contributors can run fast unit tests by default
+and opt into the full suite with `go test -tags=integration ./...`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,6 +5,8 @@ The following layers ensure we can iterate safely while surfacing regressions qu
 
 ## Unit Tests
 
+Current coverage focuses on locking in the behaviours that feed the probe engine:
+
 * `internal/config` – table-driven coverage for argument parsing, proxy detection, and service
   filtering. These tests validate defaults such as repeat counts and ensure flag changes do not
   silently break backwards compatibility.
@@ -12,12 +14,13 @@ The following layers ensure we can iterate safely while surfacing regressions qu
   notes for each Teleport version band. These tests pin behaviour such as the base16 cluster hint
   and the WebSocket-only transition in v18+.
 * `internal/probe` – TLS harnesses that spin up in-memory listeners. They now confirm that asking
-  for `teleport.example.com` via SNI returns a leaf certificate for the same host, and classify
-  ALPN mismatches and handshake failures without touching external networks.
+  for `teleport.example.com` via SNI returns a leaf certificate for the same host, record negotiated
+  ALPN values, and classify handshake failures, ALPN mismatches, and dial failures without touching
+  external networks.
 
-Unit tests will grow to include serialization helpers, SNI/ALPN builders, and any future resolvers.
-Mocks in this layer remain simple structs so that higher-level probe tests can inject synthetic
-failures without bringing up full network stacks.
+As we extend the implementation, unit tests will grow to include serialization helpers,
+SNI/ALPN builders, and any future resolvers. Mocks in this layer remain simple structs so that
+higher-level probe tests can inject synthetic failures without bringing up full network stacks.
 
 ## Probe Engine Tests
 
@@ -45,6 +48,23 @@ proxy reporting remains accurate.
 
 Until the integration environment exists, we will simulate a subset locally using `minica`-issued
 certificates and lightweight Go servers that implement the Teleport upgrade contract endpoints.
+
+### Manual validation steps
+
+Before the automated environment is online, we can still exercise the tool against a real cluster
+while minimising risk:
+
+1. Use `tsh login` to ensure a fresh profile exists under `$TELEPORT_HOME` (or `~/.tsh`). The CLI
+   will pick up the `current-profile` pointer automatically.
+2. Run `go run ./cmd/tlscheck --services proxy_web --repeat 1` to inspect the JSON plan and verify
+   that the discovered proxy address, cluster name, and Teleport version match expectations.
+3. Capture a baseline by running the probe engine against a known-good Teleport environment while
+   tailing proxy logs. Confirm that the recorded negotiated protocol, certificate subject, and ALPN
+   match the server output.
+4. Introduce controlled failures (for example, point DNS at an endpoint serving an invalid
+   certificate) and confirm that the JSON results land in the correct failure buckets. These manual
+   checks mirror the synthetic failures already covered in unit tests and provide confidence before
+   wider rollout.
 
 ## Failure Injection Helpers
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/programmerq/tlscheck
+
+go 1.24.3
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Options captures runtime inputs supplied via the CLI.
+type Options struct {
+	PublicAddr      string        `json:"public_addr"`
+	ClusterName     string        `json:"cluster_name"`
+	TeleportVersion string        `json:"teleport_version"`
+	Repeat          int           `json:"repeat"`
+	ServiceFilter   []string      `json:"service_filter,omitempty"`
+	Proxy           ProxySettings `json:"proxy"`
+	ProfileSource   *ProfileInfo  `json:"profile_source,omitempty"`
+}
+
+// ProxySettings captures HTTP(S) proxy configuration sourced from the environment.
+type ProxySettings struct {
+	HTTPSProxy string `json:"https_proxy,omitempty"`
+	HTTPProxy  string `json:"http_proxy,omitempty"`
+	NoProxy    string `json:"no_proxy,omitempty"`
+}
+
+// ProfileInfo records the Teleport profile location used for automatic defaults.
+type ProfileInfo struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+var usage func()
+
+// Usage prints the most recently configured flag usage output.
+func Usage() {
+	if usage != nil {
+		usage()
+	}
+}
+
+// ParseArgs converts CLI arguments into strongly-typed options.
+func ParseArgs(args []string, serviceKeys []string) (Options, bool, error) {
+	fs := flag.NewFlagSet("tlscheck", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	sort.Strings(serviceKeys)
+	servicesHelp := "Comma-separated service keys or 'all'"
+	if len(serviceKeys) > 0 {
+		servicesHelp = fmt.Sprintf("Comma-separated service keys (%s) or 'all'", strings.Join(serviceKeys, ", "))
+	}
+
+	var opts Options
+	var services string
+	var showVersion bool
+
+	fs.StringVar(&opts.PublicAddr, "proxy-server", "", "Teleport proxy public address (DNS name)")
+	fs.IntVar(&opts.Repeat, "repeat", 1, "Attempts per SNI/ALPN/IP combination (default 1)")
+	fs.StringVar(&services, "services", "all", servicesHelp)
+	fs.BoolVar(&showVersion, "version", false, "Print tlscheck version and exit")
+	fs.BoolVar(&showVersion, "v", false, "Print tlscheck version and exit")
+
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: %s [options]\n\n", fs.Name())
+		fmt.Fprintln(fs.Output(), "Options:")
+		fmt.Fprintf(fs.Output(), "  --proxy-server string\n\tTeleport proxy public address (DNS name)\n")
+		fmt.Fprintf(fs.Output(), "  --repeat int\n\tAttempts per SNI/ALPN/IP combination (default 1)\n")
+		fmt.Fprintf(fs.Output(), "  --services string\n\t%s\n", servicesHelp)
+		fmt.Fprintf(fs.Output(), "  -v, --version\n\tPrint tlscheck version and exit\n")
+	}
+	usage = fs.Usage
+
+	if err := fs.Parse(args); err != nil {
+		return Options{}, false, err
+	}
+
+	if opts.Repeat <= 0 {
+		return Options{}, false, fmt.Errorf("repeat must be positive (got %d)", opts.Repeat)
+	}
+
+	services = strings.TrimSpace(services)
+	if services != "" && !strings.EqualFold(services, "all") {
+		opts.ServiceFilter = splitCSV(services)
+	}
+
+	opts.Proxy = detectProxySettings()
+
+	return opts, showVersion, nil
+}
+
+func splitCSV(value string) []string {
+	raw := strings.Split(value, ",")
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		out = append(out, strings.ToLower(v))
+	}
+	return out
+}
+
+func detectProxySettings() ProxySettings {
+	return ProxySettings{
+		HTTPSProxy: firstNonEmpty(os.Getenv("HTTPS_PROXY"), os.Getenv("https_proxy")),
+		HTTPProxy:  firstNonEmpty(os.Getenv("HTTP_PROXY"), os.Getenv("http_proxy")),
+		NoProxy:    firstNonEmpty(os.Getenv("NO_PROXY"), os.Getenv("no_proxy")),
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// WantsService reports whether the options request a specific service key.
+func (o Options) WantsService(key string) bool {
+	if len(o.ServiceFilter) == 0 {
+		return true
+	}
+	key = strings.ToLower(key)
+	for _, selected := range o.ServiceFilter {
+		if selected == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1,0 +1,39 @@
+package config
+
+import "testing"
+
+func TestSplitCSV(t *testing.T) {
+	t.Parallel()
+
+	got := splitCSV(" proxy_web ,proxy_ssh , ,")
+	want := []string{"proxy_web", "proxy_ssh"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected length: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("element %d = %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOptionsWantsService(t *testing.T) {
+	t.Parallel()
+
+	opts := Options{ServiceFilter: []string{"proxy_web", "db_postgres"}}
+
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		{"proxy_web", true},
+		{"PROXY_WEB", true},
+		{"db_mysql", false},
+	}
+
+	for _, tc := range cases {
+		if got := opts.WantsService(tc.key); got != tc.want {
+			t.Fatalf("WantsService(%q) = %v want %v", tc.key, got, tc.want)
+		}
+	}
+}

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/programmerq/tlscheck/internal/discovery"
+)
+
+// ErrProxyServerRequired indicates that no proxy address could be discovered automatically.
+var ErrProxyServerRequired = errors.New("proxy server address required")
+
+// ResolveRuntime fills derived fields by consulting local profiles and the remote Teleport proxy.
+func ResolveRuntime(ctx context.Context, opts Options) (Options, error) {
+	resolved := opts
+
+	home := discovery.DefaultTeleportHome()
+	profile, profileErr := discovery.LoadActiveProfile(home)
+	if profileErr == nil {
+		if resolved.PublicAddr == "" {
+			resolved.PublicAddr = profile.PublicAddr
+		}
+		resolved.ProfileSource = &ProfileInfo{Name: profile.Name, Path: profile.Path}
+	} else if resolved.PublicAddr == "" {
+		if errors.Is(profileErr, discovery.ErrNoActiveProfile) {
+			return Options{}, ErrProxyServerRequired
+		}
+		return Options{}, fmt.Errorf("failed to load Teleport profile: %w", profileErr)
+	}
+
+	if resolved.PublicAddr == "" {
+		return Options{}, ErrProxyServerRequired
+	}
+
+	if host, _, err := net.SplitHostPort(resolved.PublicAddr); err == nil {
+		resolved.PublicAddr = host
+	}
+
+	pingAddr := resolved.PublicAddr
+	if profileErr == nil && profile.WebProxyAddr != "" {
+		pingAddr = profile.WebProxyAddr
+	}
+	if strings.Contains(opts.PublicAddr, ":") {
+		pingAddr = opts.PublicAddr
+	}
+
+	info, err := discovery.FetchClusterInfo(ctx, pingAddr, discovery.ProxySettings{
+		HTTPSProxy: resolved.Proxy.HTTPSProxy,
+		HTTPProxy:  resolved.Proxy.HTTPProxy,
+	})
+	if err != nil {
+		return Options{}, fmt.Errorf("failed to fetch cluster info: %w", err)
+	}
+
+	resolved.ClusterName = info.ClusterName
+	resolved.TeleportVersion = info.ServerVersion
+
+	return resolved, nil
+}

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveRuntimeFromProfile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/webapi/ping" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		payload := map[string]string{
+			"cluster_name":   "root.example.com",
+			"server_version": "v17.9.1",
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("encode ping payload: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	t.Setenv("TELEPORT_HOME", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "current-profile"), []byte("example.com"), 0o600); err != nil {
+		t.Fatalf("write current-profile: %v", err)
+	}
+
+	profileContent := []byte(fmt.Sprintf(`public_addr: cluster.example.com
+web_proxy_addr: %s
+ssh_proxy_addr: cluster.example.com:3080
+cluster: root.example.com
+`, srv.URL))
+	if err := os.WriteFile(filepath.Join(dir, "example.com.yaml"), profileContent, 0o600); err != nil {
+		t.Fatalf("write profile yaml: %v", err)
+	}
+
+	opts := Options{Repeat: 1}
+
+	resolved, err := ResolveRuntime(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("ResolveRuntime returned error: %v", err)
+	}
+
+	if resolved.PublicAddr != "cluster.example.com" {
+		t.Fatalf("PublicAddr = %q, want cluster.example.com", resolved.PublicAddr)
+	}
+	if resolved.ClusterName != "root.example.com" {
+		t.Fatalf("ClusterName = %q, want root.example.com", resolved.ClusterName)
+	}
+	if resolved.TeleportVersion != "v17.9.1" {
+		t.Fatalf("TeleportVersion = %q, want v17.9.1", resolved.TeleportVersion)
+	}
+	if resolved.ProfileSource == nil || resolved.ProfileSource.Name != "example.com" {
+		t.Fatalf("ProfileSource = %#v, expected example.com", resolved.ProfileSource)
+	}
+	wantPath := filepath.Join(dir, "example.com.yaml")
+	if resolved.ProfileSource.Path != wantPath {
+		t.Fatalf("ProfileSource.Path = %q, want %q", resolved.ProfileSource.Path, wantPath)
+	}
+}
+
+func TestResolveRuntimeRequiresProxy(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TELEPORT_HOME", dir)
+
+	opts := Options{Repeat: 1}
+	_, err := ResolveRuntime(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error when no profile present")
+	}
+	if err != ErrProxyServerRequired {
+		t.Fatalf("error = %v, want %v", err, ErrProxyServerRequired)
+	}
+}
+
+func TestResolveRuntimeWithExplicitProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/webapi/ping" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		payload := map[string]string{
+			"cluster_name":   "root.example.com",
+			"server_version": "v17.9.1",
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("encode ping payload: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	opts := Options{PublicAddr: srv.URL, Repeat: 1}
+
+	resolved, err := ResolveRuntime(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("ResolveRuntime returned error: %v", err)
+	}
+	if resolved.PublicAddr == "" {
+		t.Fatalf("expected PublicAddr to be populated")
+	}
+	if resolved.ClusterName != "root.example.com" {
+		t.Fatalf("ClusterName = %q, want root.example.com", resolved.ClusterName)
+	}
+	if resolved.TeleportVersion != "v17.9.1" {
+		t.Fatalf("TeleportVersion = %q, want v17.9.1", resolved.TeleportVersion)
+	}
+}

--- a/internal/discovery/ping.go
+++ b/internal/discovery/ping.go
@@ -1,0 +1,142 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ProxySettings mirrors the subset of proxy configuration required for HTTP discovery.
+type ProxySettings struct {
+	HTTPSProxy string
+	HTTPProxy  string
+}
+
+// PingInfo represents the fields gathered from /webapi/ping.
+type PingInfo struct {
+	ClusterName   string
+	ServerVersion string
+}
+
+// FetchClusterInfo retrieves cluster metadata from the proxy's /webapi/ping endpoint.
+func FetchClusterInfo(ctx context.Context, publicAddr string, proxy ProxySettings) (PingInfo, error) {
+	pingURL, err := buildPingURL(publicAddr)
+	if err != nil {
+		return PingInfo{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pingURL, nil)
+	if err != nil {
+		return PingInfo{}, fmt.Errorf("creating ping request: %w", err)
+	}
+
+	transport := &http.Transport{
+		Proxy: proxyFunc(proxy),
+	}
+	client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return PingInfo{}, fmt.Errorf("performing ping request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return PingInfo{}, fmt.Errorf("unexpected ping status: %s", resp.Status)
+	}
+
+	var payload pingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return PingInfo{}, fmt.Errorf("decoding ping response: %w", err)
+	}
+
+	info := PingInfo{
+		ClusterName:   strings.TrimSpace(payload.ClusterName),
+		ServerVersion: strings.TrimSpace(payload.ServerVersion),
+	}
+
+	if info.ClusterName == "" {
+		return PingInfo{}, fmt.Errorf("ping response missing cluster_name")
+	}
+	if info.ServerVersion == "" {
+		return PingInfo{}, fmt.Errorf("ping response missing server_version")
+	}
+
+	return info, nil
+}
+
+func buildPingURL(publicAddr string) (string, error) {
+	value := strings.TrimSpace(publicAddr)
+	if value == "" {
+		return "", fmt.Errorf("public address is empty")
+	}
+
+	if !strings.Contains(value, "://") {
+		value = "https://" + value
+	}
+
+	u, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid public address %q: %w", publicAddr, err)
+	}
+
+	if u.Scheme == "" {
+		u.Scheme = "https"
+	}
+	if u.Host == "" {
+		u.Host = value
+	}
+
+	u.Path = strings.TrimSuffix(u.Path, "/") + "/webapi/ping"
+
+	return u.String(), nil
+}
+
+func proxyFunc(settings ProxySettings) func(*http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		if req == nil {
+			return nil, nil
+		}
+
+		if strings.EqualFold(req.URL.Scheme, "https") {
+			if parsed := parseProxyURL(settings.HTTPSProxy); parsed != nil {
+				return parsed, nil
+			}
+			if parsed := parseProxyURL(settings.HTTPProxy); parsed != nil {
+				return parsed, nil
+			}
+		}
+
+		if strings.EqualFold(req.URL.Scheme, "http") {
+			if parsed := parseProxyURL(settings.HTTPProxy); parsed != nil {
+				return parsed, nil
+			}
+		}
+
+		return nil, nil
+	}
+}
+
+func parseProxyURL(raw string) *url.URL {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	return parsed
+}
+
+type pingResponse struct {
+	ClusterName   string `json:"cluster_name"`
+	ServerVersion string `json:"server_version"`
+}

--- a/internal/discovery/ping_test.go
+++ b/internal/discovery/ping_test.go
@@ -1,0 +1,39 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchClusterInfo(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/webapi/ping" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		payload := map[string]string{
+			"cluster_name":   "root.example.com",
+			"server_version": "v17.3.2",
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("failed to encode payload: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	info, err := FetchClusterInfo(context.Background(), srv.URL, ProxySettings{})
+	if err != nil {
+		t.Fatalf("FetchClusterInfo returned error: %v", err)
+	}
+
+	if info.ClusterName != "root.example.com" {
+		t.Fatalf("ClusterName = %q, want root.example.com", info.ClusterName)
+	}
+	if info.ServerVersion != "v17.3.2" {
+		t.Fatalf("ServerVersion = %q, want v17.3.2", info.ServerVersion)
+	}
+}

--- a/internal/discovery/profile.go
+++ b/internal/discovery/profile.go
@@ -1,0 +1,230 @@
+package discovery
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Profile describes a Teleport profile entry discovered on disk.
+type Profile struct {
+	Name         string
+	PublicAddr   string
+	ClusterName  string
+	Path         string
+	WebProxyAddr string
+}
+
+// ErrNoActiveProfile indicates that no active Teleport profile could be located.
+var ErrNoActiveProfile = errors.New("no active Teleport profile")
+
+// DefaultTeleportHome resolves the Teleport home directory.
+func DefaultTeleportHome() string {
+	if env := strings.TrimSpace(os.Getenv("TELEPORT_HOME")); env != "" {
+		return env
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".tsh")
+}
+
+// LoadActiveProfile locates the active Teleport profile from the current-profile marker.
+func LoadActiveProfile(home string) (Profile, error) {
+	if strings.TrimSpace(home) == "" {
+		return Profile{}, ErrNoActiveProfile
+	}
+
+	name, err := readCurrentProfileName(home)
+	if err != nil {
+		if errors.Is(err, ErrNoActiveProfile) {
+			return loadFromProfilesYAML(home)
+		}
+		return Profile{}, err
+	}
+
+	return loadProfileFile(home, name)
+}
+
+func readCurrentProfileName(home string) (string, error) {
+	path := filepath.Join(home, "current-profile")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ErrNoActiveProfile
+		}
+		return "", fmt.Errorf("reading current-profile: %w", err)
+	}
+	name := strings.TrimSpace(string(data))
+	if name == "" {
+		return "", ErrNoActiveProfile
+	}
+	return name, nil
+}
+
+func loadProfileFile(home, name string) (Profile, error) {
+	path := filepath.Join(home, fmt.Sprintf("%s.yaml", name))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Profile{}, ErrNoActiveProfile
+		}
+		return Profile{}, fmt.Errorf("reading profile %q: %w", name, err)
+	}
+
+	var parsed tshProfile
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return Profile{}, fmt.Errorf("decoding profile %q: %w", name, err)
+	}
+
+	publicAddr := normalizeHost(parsed.PublicAddr)
+	if publicAddr == "" {
+		publicAddr = normalizeHost(parsed.SSHProxyAddr)
+	}
+	if publicAddr == "" {
+		publicAddr = normalizeHost(parsed.WebProxyAddr)
+	}
+	if publicAddr == "" {
+		return Profile{}, fmt.Errorf("profile %q does not define a proxy address", name)
+	}
+
+	profile := Profile{
+		Name:         name,
+		PublicAddr:   publicAddr,
+		ClusterName:  strings.TrimSpace(firstNonEmpty(parsed.Cluster, name)),
+		Path:         path,
+		WebProxyAddr: strings.TrimSpace(firstNonEmpty(parsed.WebProxyAddr, parsed.SSHProxyAddr, parsed.PublicAddr)),
+	}
+
+	if profile.WebProxyAddr == "" {
+		profile.WebProxyAddr = publicAddr
+	}
+
+	return profile, nil
+}
+
+func loadFromProfilesYAML(home string) (Profile, error) {
+	path := filepath.Join(home, "profiles.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Profile{}, ErrNoActiveProfile
+		}
+		return Profile{}, fmt.Errorf("reading profiles.yaml: %w", err)
+	}
+
+	var parsed profilesFile
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return Profile{}, fmt.Errorf("decoding profiles.yaml: %w", err)
+	}
+
+	profileName := strings.TrimSpace(parsed.CurrentProfile)
+	if profileName == "" && len(parsed.Profiles) == 1 {
+		profileName = parsed.Profiles[0].Name
+	}
+	if profileName == "" {
+		return Profile{}, ErrNoActiveProfile
+	}
+
+	entry, ok := parsed.byName(profileName)
+	if !ok {
+		return Profile{}, fmt.Errorf("profile %q not present in profiles.yaml", profileName)
+	}
+
+	publicAddr := normalizeHost(entry.PublicAddr)
+	if publicAddr == "" {
+		publicAddr = normalizeHost(entry.ProxyURL)
+	}
+	if publicAddr == "" {
+		publicAddr = normalizeHost(entry.WebProxyAddr)
+	}
+	if publicAddr == "" {
+		return Profile{}, fmt.Errorf("profile %q does not define a proxy address", entry.Name)
+	}
+
+	profile := Profile{
+		Name:         entry.Name,
+		PublicAddr:   publicAddr,
+		ClusterName:  strings.TrimSpace(firstNonEmpty(entry.Cluster, entry.Name)),
+		Path:         filepath.Join(home, fmt.Sprintf("%s.yaml", entry.Name)),
+		WebProxyAddr: strings.TrimSpace(firstNonEmpty(entry.WebProxyAddr, entry.ProxyURL, entry.PublicAddr)),
+	}
+	if profile.WebProxyAddr == "" {
+		profile.WebProxyAddr = publicAddr
+	}
+
+	return profile, nil
+}
+
+type tshProfile struct {
+	WebProxyAddr string `yaml:"web_proxy_addr"`
+	SSHProxyAddr string `yaml:"ssh_proxy_addr"`
+	PublicAddr   string `yaml:"public_addr"`
+	Cluster      string `yaml:"cluster"`
+}
+
+type profilesFile struct {
+	CurrentProfile string          `yaml:"current_profile"`
+	Profiles       []profileRecord `yaml:"profiles"`
+}
+
+type profileRecord struct {
+	Name         string `yaml:"name"`
+	PublicAddr   string `yaml:"public_addr"`
+	ProxyURL     string `yaml:"proxy_url"`
+	WebProxyAddr string `yaml:"web_proxy_addr"`
+	Cluster      string `yaml:"cluster"`
+}
+
+func (p profilesFile) byName(name string) (profileRecord, bool) {
+	for _, rec := range p.Profiles {
+		if rec.Name == name {
+			return rec, true
+		}
+	}
+	return profileRecord{}, false
+}
+
+func normalizeHost(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		if u, err := url.Parse(value); err == nil {
+			host := u.Hostname()
+			if host != "" {
+				return host
+			}
+			if u.Host != "" {
+				if host, _, err := net.SplitHostPort(u.Host); err == nil {
+					return host
+				}
+				return u.Host
+			}
+		}
+	}
+
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		return host
+	}
+
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/discovery/profile_test.go
+++ b/internal/discovery/profile_test.go
@@ -1,0 +1,87 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadActiveProfileCurrentProfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "current-profile"), []byte("teleport.example.com"), 0o600); err != nil {
+		t.Fatalf("failed to write current-profile: %v", err)
+	}
+
+	profileContent := []byte(`public_addr: cluster.example.com
+web_proxy_addr: cluster.example.com:443
+ssh_proxy_addr: cluster.example.com:3080
+cluster: root.example.com
+`)
+	if err := os.WriteFile(filepath.Join(dir, "teleport.example.com.yaml"), profileContent, 0o600); err != nil {
+		t.Fatalf("failed to write profile yaml: %v", err)
+	}
+
+	profile, err := LoadActiveProfile(dir)
+	if err != nil {
+		t.Fatalf("LoadActiveProfile returned error: %v", err)
+	}
+
+	if profile.Name != "teleport.example.com" {
+		t.Fatalf("Name = %q, want teleport.example.com", profile.Name)
+	}
+	if profile.PublicAddr != "cluster.example.com" {
+		t.Fatalf("PublicAddr = %q, want cluster.example.com", profile.PublicAddr)
+	}
+	if profile.WebProxyAddr != "cluster.example.com:443" {
+		t.Fatalf("WebProxyAddr = %q, want cluster.example.com:443", profile.WebProxyAddr)
+	}
+	if profile.ClusterName != "root.example.com" {
+		t.Fatalf("ClusterName = %q, want root.example.com", profile.ClusterName)
+	}
+	wantPath := filepath.Join(dir, "teleport.example.com.yaml")
+	if profile.Path != wantPath {
+		t.Fatalf("Path = %q, want %q", profile.Path, wantPath)
+	}
+}
+
+func TestLoadActiveProfileLegacy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := []byte(`current_profile: example.com
+profiles:
+  - name: example.com
+    public_addr: cluster.example.com
+    proxy_url: cluster.example.com:3080
+    web_proxy_addr: cluster.example.com:3080
+    cluster: root.example.com
+`)
+	if err := os.WriteFile(filepath.Join(dir, "profiles.yaml"), content, 0o600); err != nil {
+		t.Fatalf("failed to write profiles.yaml: %v", err)
+	}
+
+	profile, err := LoadActiveProfile(dir)
+	if err != nil {
+		t.Fatalf("LoadActiveProfile returned error: %v", err)
+	}
+
+	if profile.PublicAddr != "cluster.example.com" {
+		t.Fatalf("PublicAddr = %q, want cluster.example.com", profile.PublicAddr)
+	}
+
+	if profile.WebProxyAddr != "cluster.example.com:3080" {
+		t.Fatalf("WebProxyAddr = %q, want cluster.example.com:3080", profile.WebProxyAddr)
+	}
+
+	if profile.ClusterName != "root.example.com" {
+		t.Fatalf("ClusterName = %q, want root.example.com", profile.ClusterName)
+	}
+
+	wantPath := filepath.Join(dir, "example.com.yaml")
+	if profile.Path != wantPath {
+		t.Fatalf("Path = %q, want %q", profile.Path, wantPath)
+	}
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,0 +1,420 @@
+package plan
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/programmerq/tlscheck/internal/config"
+)
+
+// Plan captures the probe blueprint derived from CLI inputs.
+type Plan struct {
+	GeneratedAt        time.Time        `json:"generated_at"`
+	Options            config.Options   `json:"options"`
+	VersionBand        string           `json:"version_band"`
+	Base16ClusterName  string           `json:"base16_cluster_name"`
+	DefaultUpgradePath []UpgradeAttempt `json:"default_upgrade_path"`
+	Targets            []ProbeTarget    `json:"targets"`
+}
+
+// ProbeTarget represents a specific (port, SNI, ALPN) combination to execute.
+type ProbeTarget struct {
+	ServiceKey      string           `json:"service_key"`
+	DisplayName     string           `json:"display_name"`
+	Address         string           `json:"address"`
+	Port            int              `json:"port"`
+	PrimarySNI      string           `json:"primary_sni"`
+	AdditionalSNIs  []string         `json:"additional_snis,omitempty"`
+	ALPNs           []string         `json:"alpns"`
+	UpgradeSequence []UpgradeAttempt `json:"upgrade_sequence"`
+	Repeat          int              `json:"repeat"`
+	Notes           []string         `json:"notes,omitempty"`
+}
+
+// UpgradeAttempt documents the sequence of Upgrade headers to send behind L7 load balancers.
+type UpgradeAttempt struct {
+	Token string `json:"token"`
+	Path  string `json:"path"`
+}
+
+const upgradeEndpoint = "/webapi/connectionupgrade"
+
+// Build assembles a probe plan according to user options and version defaults.
+func Build(opts config.Options) (Plan, error) {
+	seq := determineUpgradeSequence(opts.TeleportVersion)
+	versionBand := describeVersionBand(opts.TeleportVersion)
+	base16Name := strings.ToLower(hex.EncodeToString([]byte(opts.ClusterName)))
+
+	tmplFilter := map[string]struct{}{}
+	filtering := len(opts.ServiceFilter) > 0
+	if filtering {
+		for _, key := range makeUnique(opts.ServiceFilter) {
+			tmplFilter[key] = struct{}{}
+		}
+	}
+
+	plan := Plan{
+		GeneratedAt:        time.Now().UTC(),
+		Options:            opts,
+		VersionBand:        versionBand,
+		Base16ClusterName:  base16Name,
+		DefaultUpgradePath: seq,
+	}
+
+	for _, tmpl := range serviceTemplates {
+		if filtering {
+			if _, ok := tmplFilter[tmpl.Key]; !ok {
+				continue
+			}
+			delete(tmplFilter, tmpl.Key)
+		}
+
+		targets := tmpl.instantiate(opts, base16Name, seq)
+		plan.Targets = append(plan.Targets, targets...)
+	}
+
+	if len(tmplFilter) > 0 {
+		remaining := make([]string, 0, len(tmplFilter))
+		for key := range tmplFilter {
+			remaining = append(remaining, key)
+		}
+		return Plan{}, fmt.Errorf("unknown services requested: %s", strings.Join(remaining, ", "))
+	}
+
+	return plan, nil
+}
+
+type serviceTemplate struct {
+	Key          string
+	DisplayName  string
+	Ports        []int
+	ALPNs        func(config.Options) []string
+	SNIs         func(config.Options) (string, []string)
+	Notes        []string
+	NeedsUpgrade bool
+	Base16Hint   bool
+}
+
+func (t serviceTemplate) instantiate(opts config.Options, base16Name string, seq []UpgradeAttempt) []ProbeTarget {
+	alpns := t.ALPNs(opts)
+	primarySNI, additionalSNIs := t.SNIs(opts)
+
+	targets := make([]ProbeTarget, 0, len(t.Ports))
+	for _, port := range t.Ports {
+		target := ProbeTarget{
+			ServiceKey:     t.Key,
+			DisplayName:    t.DisplayName,
+			Address:        opts.PublicAddr,
+			Port:           port,
+			PrimarySNI:     primarySNI,
+			AdditionalSNIs: cloneSlice(additionalSNIs),
+			ALPNs:          cloneSlice(alpns),
+			Repeat:         opts.Repeat,
+			Notes:          cloneSlice(t.Notes),
+		}
+
+		if t.NeedsUpgrade {
+			target.UpgradeSequence = cloneUpgrades(seq)
+		}
+
+		targets = append(targets, target)
+	}
+
+	// Some services implicitly need to record the base16 cluster hint.
+	if t.Base16Hint && len(targets) > 0 && base16Name != "" {
+		targets[0].Notes = append(targets[0].Notes,
+			fmt.Sprintf("base16 cluster name hint: %s", base16Name))
+	}
+
+	return targets
+}
+
+func cloneSlice(input []string) []string {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make([]string, len(input))
+	copy(out, input)
+	return out
+}
+
+func cloneUpgrades(input []UpgradeAttempt) []UpgradeAttempt {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make([]UpgradeAttempt, len(input))
+	copy(out, input)
+	return out
+}
+
+var serviceTemplates = []serviceTemplate{
+	{
+		Key:         "proxy_web",
+		DisplayName: "Proxy Web UI & HTTPS API",
+		Ports:       []int{3080, 443},
+		ALPNs: func(config.Options) []string {
+			return []string{"h2", "http/1.1"}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"Hit /webapi/ping before attempting upgrade",
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "reverse_tunnel",
+		DisplayName: "Reverse tunnel entry",
+		Ports:       []int{3024},
+		ALPNs: func(config.Options) []string {
+			return []string{"teleport-reversetunnel"}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"Probe direct IPs returned for the proxy host as well",
+		},
+		NeedsUpgrade: true,
+		Base16Hint:   true,
+	},
+	{
+		Key:         "proxy_ssh",
+		DisplayName: "Proxy SSH",
+		Ports:       []int{3023},
+		ALPNs: func(config.Options) []string {
+			return []string{"teleport-proxy-ssh"}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"Include base16 cluster SNI when dialing resolved IPs",
+		},
+		NeedsUpgrade: true,
+		Base16Hint:   true,
+	},
+	{
+		Key:         "proxy_ssh_grpc",
+		DisplayName: "Proxy SSH gRPC",
+		Ports:       []int{3023},
+		ALPNs: func(config.Options) []string {
+			return []string{"teleport-proxy-ssh-grpc"}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "auth_via_proxy",
+		DisplayName: "Auth via proxy",
+		Ports:       []int{3025},
+		ALPNs: func(opts config.Options) []string {
+			return []string{fmt.Sprintf("teleport-auth@%s", opts.ClusterName)}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"Expect Host CA issued leaf cert with auth identity",
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "kubernetes",
+		DisplayName: "Kubernetes API via proxy",
+		Ports:       []int{3026},
+		ALPNs: func(config.Options) []string {
+			return []string{"h2", "http/1.1"}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return fmt.Sprintf("kube-teleport-proxy-alpn.%s", opts.ClusterName), []string{opts.PublicAddr}
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "db_postgres",
+		DisplayName: "Database listener (Postgres)",
+		Ports:       []int{5432},
+		ALPNs: func(config.Options) []string {
+			return nil
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"ALPN negotiated by tsh db proxy; harness verifies upstream reachability",
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "db_mysql",
+		DisplayName: "Database listener (MySQL)",
+		Ports:       []int{3036},
+		ALPNs: func(config.Options) []string {
+			return nil
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"ALPN negotiated by tsh db proxy; harness verifies upstream reachability",
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "db_mongodb",
+		DisplayName: "Database listener (MongoDB)",
+		Ports:       []int{27017},
+		ALPNs: func(config.Options) []string {
+			return nil
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"ALPN negotiated by tsh db proxy; harness verifies upstream reachability",
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "db_redis",
+		DisplayName: "Database listener (Redis)",
+		Ports:       []int{6379},
+		ALPNs: func(config.Options) []string {
+			return nil
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"ALPN negotiated by tsh db proxy; harness verifies upstream reachability",
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "app_access",
+		DisplayName: "App Access",
+		Ports:       []int{3080, 443},
+		ALPNs: func(config.Options) []string {
+			return []string{"h2", "http/1.1"}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		NeedsUpgrade: true,
+	},
+	{
+		Key:         "desktop_access",
+		DisplayName: "Desktop Access",
+		Ports:       []int{3080, 443},
+		ALPNs: func(config.Options) []string {
+			return []string{"h2", "http/1.1"}
+		},
+		SNIs: func(opts config.Options) (string, []string) {
+			return opts.PublicAddr, nil
+		},
+		Notes: []string{
+			"Desktop Access uses gRPC over HTTP/2",
+		},
+		NeedsUpgrade: true,
+	},
+}
+
+// ServiceKeys returns the valid service identifiers that can be filtered via CLI flags.
+func ServiceKeys() []string {
+	keys := make([]string, 0, len(serviceTemplates))
+	for _, tmpl := range serviceTemplates {
+		keys = append(keys, tmpl.Key)
+	}
+	return keys
+}
+
+func determineUpgradeSequence(version string) []UpgradeAttempt {
+	major, minor := parseVersion(version)
+
+	switch {
+	case major >= 18:
+		return []UpgradeAttempt{{Token: "websocket", Path: upgradeEndpoint}}
+	case major == 17:
+		return []UpgradeAttempt{
+			{Token: "websocket", Path: upgradeEndpoint},
+			{Token: "alpn", Path: upgradeEndpoint},
+			{Token: "alpn-ping", Path: upgradeEndpoint},
+		}
+	case major == 16:
+		fallthrough
+	case major == 15 && minor >= 1:
+		return []UpgradeAttempt{
+			{Token: "websocket", Path: upgradeEndpoint},
+			{Token: "alpn", Path: upgradeEndpoint},
+			{Token: "alpn-ping", Path: upgradeEndpoint},
+		}
+	default:
+		return []UpgradeAttempt{
+			{Token: "alpn", Path: upgradeEndpoint},
+			{Token: "alpn-ping", Path: upgradeEndpoint},
+		}
+	}
+}
+
+func describeVersionBand(version string) string {
+	major, _ := parseVersion(version)
+	switch {
+	case major >= 18:
+		return "v18+"
+	case major >= 15:
+		return "v15–v17"
+	default:
+		return "pre-v15"
+	}
+}
+
+func parseVersion(input string) (int, int) {
+	trimmed := strings.TrimSpace(input)
+	trimmed = strings.TrimPrefix(trimmed, "v")
+	parts := strings.Split(trimmed, ".")
+
+	major := atoi(parts, 0)
+	minor := atoi(parts, 1)
+	return major, minor
+}
+
+func atoi(parts []string, idx int) int {
+	if idx >= len(parts) {
+		return 0
+	}
+	value := parts[idx]
+	if value == "" {
+		return 0
+	}
+	n := 0
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+func makeUnique(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.ToLower(strings.TrimSpace(v))
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,148 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/programmerq/tlscheck/internal/config"
+)
+
+func TestDetermineUpgradeSequence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		version  string
+		expected []UpgradeAttempt
+	}{
+		{
+			name:    "pre-v15 uses legacy upgrades",
+			version: "v14.2.9",
+			expected: []UpgradeAttempt{
+				{Token: "alpn", Path: upgradeEndpoint},
+				{Token: "alpn-ping", Path: upgradeEndpoint},
+			},
+		},
+		{
+			name:    "v15.1 adds websocket",
+			version: "v15.1.0",
+			expected: []UpgradeAttempt{
+				{Token: "websocket", Path: upgradeEndpoint},
+				{Token: "alpn", Path: upgradeEndpoint},
+				{Token: "alpn-ping", Path: upgradeEndpoint},
+			},
+		},
+		{
+			name:    "v17 keeps websocket and legacy",
+			version: "v17.3.2",
+			expected: []UpgradeAttempt{
+				{Token: "websocket", Path: upgradeEndpoint},
+				{Token: "alpn", Path: upgradeEndpoint},
+				{Token: "alpn-ping", Path: upgradeEndpoint},
+			},
+		},
+		{
+			name:    "v18 is websocket only",
+			version: "v18.0.0",
+			expected: []UpgradeAttempt{
+				{Token: "websocket", Path: upgradeEndpoint},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := determineUpgradeSequence(tt.version)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("sequence length mismatch: got %d want %d", len(got), len(tt.expected))
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Fatalf("sequence[%d] = %#v want %#v", i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildFiltersServices(t *testing.T) {
+	t.Parallel()
+
+	opts := config.Options{
+		PublicAddr:      "cluster.example.com",
+		ClusterName:     "example",
+		TeleportVersion: "v17.3.2",
+		Repeat:          1,
+		ServiceFilter:   []string{"proxy_web"},
+	}
+
+	plan, err := Build(opts)
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if len(plan.Targets) == 0 {
+		t.Fatalf("expected at least one target for proxy_web")
+	}
+
+	for _, target := range plan.Targets {
+		if target.ServiceKey != "proxy_web" {
+			t.Fatalf("unexpected service %q in filtered plan", target.ServiceKey)
+		}
+	}
+}
+
+func TestBuildUnknownService(t *testing.T) {
+	t.Parallel()
+
+	opts := config.Options{
+		PublicAddr:      "cluster.example.com",
+		ClusterName:     "example",
+		TeleportVersion: "v17.3.2",
+		Repeat:          1,
+		ServiceFilter:   []string{"proxy_web", "does_not_exist"},
+	}
+
+	if _, err := Build(opts); err == nil {
+		t.Fatalf("expected error when unknown service requested")
+	}
+}
+
+func TestBuildBase16Hint(t *testing.T) {
+	t.Parallel()
+
+	opts := config.Options{
+		PublicAddr:      "cluster.example.com",
+		ClusterName:     "example",
+		TeleportVersion: "v17.3.2",
+		Repeat:          1,
+	}
+
+	plan, err := Build(opts)
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if plan.Base16ClusterName != "6578616d706c65" { // "example" in hex
+		t.Fatalf("unexpected base16 cluster name: %q", plan.Base16ClusterName)
+	}
+
+	found := false
+	for _, target := range plan.Targets {
+		for _, note := range target.Notes {
+			if strings.Contains(note, "6578616d706c65") {
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected at least one target to include base16 hint note")
+	}
+}

--- a/internal/probe/engine.go
+++ b/internal/probe/engine.go
@@ -134,9 +134,9 @@ func classifyDialError(err error) string {
 		if ne.Timeout() {
 			return "timeout"
 		}
-		if ne.Temporary() {
-			return "handshake_failed"
-		}
+		// net.Error.Temporary is deprecated and no longer reliable for
+		// classifying errors. Prefer explicit checks for known error types
+		// if we need to add more buckets in the future.
 	}
 	return "proxy_connect_failed"
 }

--- a/internal/probe/engine.go
+++ b/internal/probe/engine.go
@@ -1,0 +1,151 @@
+package probe
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/programmerq/tlscheck/internal/plan"
+)
+
+// Dialer defines the minimal interface required for TCP connections.
+// net.Dialer satisfies this interface.
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Engine executes probe targets against a Teleport proxy.
+type Engine struct {
+	Dialer  Dialer
+	Timeout time.Duration
+	RootCAs *x509.CertPool
+}
+
+// Result captures the outcome of a single probe attempt.
+type Result struct {
+	Target             plan.ProbeTarget `json:"target"`
+	Attempt            int              `json:"attempt"`
+	RemoteAddr         string           `json:"remote_addr,omitempty"`
+	NegotiatedProtocol string           `json:"negotiated_protocol,omitempty"`
+	LeafSubject        string           `json:"leaf_subject,omitempty"`
+	LeafFingerprint    string           `json:"leaf_fingerprint,omitempty"`
+	Failure            *Failure         `json:"failure,omitempty"`
+}
+
+// Failure describes a classified probe error.
+type Failure struct {
+	Kind    string `json:"kind"`
+	Message string `json:"message"`
+}
+
+// NewEngine constructs an Engine with sensible defaults.
+func NewEngine() *Engine {
+	return &Engine{
+		Dialer:  &net.Dialer{Timeout: 10 * time.Second},
+		Timeout: 15 * time.Second,
+	}
+}
+
+// Run executes the provided plan and returns probe results.
+func (e *Engine) Run(ctx context.Context, p plan.Plan) ([]Result, error) {
+	if e.Dialer == nil {
+		return nil, fmt.Errorf("probe engine requires a dialer")
+	}
+
+	results := make([]Result, 0)
+	for _, target := range p.Targets {
+		repeat := target.Repeat
+		if repeat <= 0 {
+			repeat = 1
+		}
+		for attempt := 1; attempt <= repeat; attempt++ {
+			res := e.probeOnce(ctx, target, attempt)
+			results = append(results, res)
+		}
+	}
+	return results, nil
+}
+
+func (e *Engine) probeOnce(ctx context.Context, target plan.ProbeTarget, attempt int) Result {
+	res := Result{Target: target, Attempt: attempt}
+
+	dialCtx, cancel := context.WithTimeout(ctx, e.Timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(target.Address, fmt.Sprintf("%d", target.Port))
+	conn, err := e.Dialer.DialContext(dialCtx, "tcp", addr)
+	if err != nil {
+		res.Failure = &Failure{Kind: classifyDialError(err), Message: err.Error()}
+		return res
+	}
+	defer conn.Close()
+
+	tlsCfg := &tls.Config{
+		ServerName: target.PrimarySNI,
+		NextProtos: target.ALPNs,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    e.RootCAs,
+	}
+
+	tlsConn := tls.Client(conn, tlsCfg)
+	if err := tlsConn.HandshakeContext(dialCtx); err != nil {
+		kind := "handshake_failed"
+		if strings.Contains(err.Error(), "no application protocol") {
+			kind = "alpn_mismatch"
+		}
+		res.Failure = &Failure{Kind: kind, Message: err.Error()}
+		return res
+	}
+	defer tlsConn.Close()
+
+	state := tlsConn.ConnectionState()
+	res.RemoteAddr = conn.RemoteAddr().String()
+	res.NegotiatedProtocol = state.NegotiatedProtocol
+
+	if len(target.ALPNs) > 0 {
+		if state.NegotiatedProtocol == "" {
+			res.Failure = &Failure{Kind: "alpn_mismatch", Message: "server did not negotiate ALPN"}
+			return res
+		}
+		if !contains(target.ALPNs, state.NegotiatedProtocol) {
+			res.Failure = &Failure{Kind: "alpn_mismatch", Message: fmt.Sprintf("negotiated %s", state.NegotiatedProtocol)}
+			return res
+		}
+	}
+
+	if len(state.PeerCertificates) > 0 {
+		leaf := state.PeerCertificates[0]
+		sum := sha256.Sum256(leaf.Raw)
+		res.LeafFingerprint = strings.ToUpper(hex.EncodeToString(sum[:]))
+		res.LeafSubject = leaf.Subject.String()
+	}
+
+	return res
+}
+
+func classifyDialError(err error) string {
+	if ne, ok := err.(net.Error); ok {
+		if ne.Timeout() {
+			return "timeout"
+		}
+		if ne.Temporary() {
+			return "handshake_failed"
+		}
+	}
+	return "proxy_connect_failed"
+}
+
+func contains(values []string, needle string) bool {
+	for _, v := range values {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/probe/engine_test.go
+++ b/internal/probe/engine_test.go
@@ -1,0 +1,257 @@
+package probe
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/programmerq/tlscheck/internal/plan"
+)
+
+func TestEngineHandshakeSuccess(t *testing.T) {
+	t.Parallel()
+
+	cert, pool := generateServerCert(t, "teleport.example.com")
+	addr, cleanup := startTLSServer(t, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2"},
+	}, nil)
+	t.Cleanup(cleanup)
+
+	host, port := splitHostPort(t, addr)
+	target := plan.ProbeTarget{
+		ServiceKey:      "proxy_web",
+		Address:         host,
+		Port:            port,
+		PrimarySNI:      "teleport.example.com",
+		ALPNs:           []string{"h2", "http/1.1"},
+		Repeat:          1,
+		UpgradeSequence: nil,
+	}
+
+	engine := NewEngine()
+	engine.RootCAs = pool
+
+	probePlan := plan.Plan{Targets: []plan.ProbeTarget{target}}
+	results, err := engine.Run(context.Background(), probePlan)
+	if err != nil {
+		t.Fatalf("engine.Run returned error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	res := results[0]
+	if res.Failure != nil {
+		t.Fatalf("expected success, got failure: %#v", res.Failure)
+	}
+	if res.NegotiatedProtocol != "h2" {
+		t.Fatalf("negotiated protocol = %q, want h2", res.NegotiatedProtocol)
+	}
+	if res.LeafFingerprint == "" || res.LeafSubject == "" {
+		t.Fatalf("expected certificate details to be populated")
+	}
+	if res.LeafSubject != "CN=teleport.example.com" {
+		t.Fatalf("LeafSubject = %q, want CN=teleport.example.com", res.LeafSubject)
+	}
+}
+
+func TestEngineALPNMismatch(t *testing.T) {
+	t.Parallel()
+
+	cert, pool := generateServerCert(t, "cluster.example.com")
+	addr, cleanup := startTLSServer(t, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"http/1.1"},
+	}, nil)
+	t.Cleanup(cleanup)
+
+	host, port := splitHostPort(t, addr)
+	target := plan.ProbeTarget{
+		ServiceKey: "proxy_web",
+		Address:    host,
+		Port:       port,
+		PrimarySNI: "cluster.example.com",
+		ALPNs:      []string{"h2"},
+	}
+
+	engine := NewEngine()
+	engine.RootCAs = pool
+
+	probePlan := plan.Plan{Targets: []plan.ProbeTarget{target}}
+	results, err := engine.Run(context.Background(), probePlan)
+	if err != nil {
+		t.Fatalf("engine.Run returned error: %v", err)
+	}
+	if results[0].Failure == nil || results[0].Failure.Kind != "alpn_mismatch" {
+		t.Fatalf("expected alpn_mismatch failure, got %#v", results[0].Failure)
+	}
+}
+
+func TestEngineHandshakeFailure(t *testing.T) {
+	t.Parallel()
+
+	addr, cleanup := startFailingServer(t)
+	t.Cleanup(cleanup)
+
+	host, port := splitHostPort(t, addr)
+	target := plan.ProbeTarget{
+		ServiceKey: "proxy_web",
+		Address:    host,
+		Port:       port,
+		PrimarySNI: "cluster.example.com",
+		ALPNs:      []string{"h2"},
+	}
+
+	engine := NewEngine()
+
+	probePlan := plan.Plan{Targets: []plan.ProbeTarget{target}}
+	results, err := engine.Run(context.Background(), probePlan)
+	if err != nil {
+		t.Fatalf("engine.Run returned error: %v", err)
+	}
+	if results[0].Failure == nil || results[0].Failure.Kind != "handshake_failed" {
+		t.Fatalf("expected handshake_failed, got %#v", results[0].Failure)
+	}
+}
+
+func generateServerCert(t *testing.T, host string) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tlscheck test ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: host},
+		DNSNames:     []string{host},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("load key pair: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	return cert, pool
+}
+
+func startTLSServer(t *testing.T, cfg *tls.Config, handler func(*tls.Conn)) (string, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	var once sync.Once
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(conn, cfg)
+		if err := tlsConn.Handshake(); err == nil {
+			if handler != nil {
+				handler(tlsConn)
+			}
+		}
+		tlsConn.Close()
+		once.Do(func() { ln.Close() })
+	}()
+
+	cleanup := func() {
+		once.Do(func() { ln.Close() })
+		<-done
+	}
+
+	return ln.Addr().String(), cleanup
+}
+
+func startFailingServer(t *testing.T) (string, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		conn.Close()
+		ln.Close()
+	}()
+
+	cleanup := func() {
+		ln.Close()
+		<-done
+	}
+
+	return ln.Addr().String(), cleanup
+}
+
+func splitHostPort(t *testing.T, addr string) (string, int) {
+	t.Helper()
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("Atoi(%q): %v", portStr, err)
+	}
+	return host, port
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version captures the build identifier for tlscheck.
+var Version = "dev"


### PR DESCRIPTION
## Summary
- update the CLI to use --proxy-server, resolve cluster metadata from Teleport profiles and /webapi/ping, and add a -v/--version flag
- teach discovery to read ~/.tsh/current-profile (with legacy fallback) and document the new defaults
- extend TLS probe tests to assert the requested SNI returns the expected certificate subject and add a version package for build info

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68f66ffca620833393327e72f5c48311